### PR TITLE
Adding customization hooks

### DIFF
--- a/chart/kiosk/templates/daemonset.yaml
+++ b/chart/kiosk/templates/daemonset.yaml
@@ -92,8 +92,14 @@ spec:
           securityContext:
             runAsUser: 1000
           env: 
+          {{- range .Values.workload.env }}
+          - name: "{{ .name }}"
+            value: "{{ .value }}"
+          {{- end }}
+          {{ if .Values.workload.url }}
           - name: URL
             value: "{{ .Values.workload.url }}"
+          {{ end }}
           - name: PULSE_SERVER
             value: "/var/run/pulse/native"
           - name: DISPLAY
@@ -111,6 +117,14 @@ spec:
             - mountPath: /home/user/.pki
               name: nssdb
             {{ end }}
+            {{- range .Values.workload.additionalSecrets }}
+            - name: "extsecret-wl-{{ .name }}"
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- range .Values.workload.additionalConfigMaps }}
+            - name: "extconfig-wl-{{ .name }}"
+              mountPath: {{ .mountPath }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{ if .Values.vnc.enabled }}
@@ -164,3 +178,13 @@ spec:
           secret: 
             secretName: {{ .Values.workload.nssdbSecretName }}
         {{ end }}
+        {{- range .Values.workload.additionalSecrets }}
+        - name: "extsecret-wl-{{ .name }}"
+          secret: 
+            secretName: "{{ .name }}"
+        {{- end }}
+        {{- range .Values.workload.additionalConfigMaps }}
+        - name: "extconfig-wl-{{ .name }}"
+          configMap: 
+            name: "{{ .name }}"
+        {{- end }}

--- a/chart/kiosk/templates/daemonset.yaml
+++ b/chart/kiosk/templates/daemonset.yaml
@@ -44,6 +44,11 @@ spec:
               subPath: .Xmodmap
               name: xmodmap
             {{- end }}
+            {{- with .Values.X11.xinitrcOverride }}
+            - mountPath: /etc/X11/xinit/
+              subPath: xinitrc
+              name: xinitrc
+            {{- end }}
         - name: pulseaudio
           image: {{ .Values.pulseaudio.image.repository }}:{{ .Values.pulseaudio.image.tag }}
           imagePullPolicy: {{ .Values.pulseaudio.image.pullPolicy }}
@@ -170,6 +175,11 @@ spec:
         - name: xmodmap
           configMap:
             name: xmodmap
+        {{- end }}
+        {{- with .Values.X11.xinitrcOverride }}
+        - name: xinitrc
+          configMap: 
+            name: xinitrc
         {{- end }}
         {{ if .Values.workload.nssdbSecretName }}
         - name: nssdb

--- a/chart/kiosk/templates/xinitrc-configmap.yaml
+++ b/chart/kiosk/templates/xinitrc-configmap.yaml
@@ -1,0 +1,9 @@
+{{- with .Values.X11.xinitrcOverride }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: xinitrc
+data:
+  xinitrc:
+  {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/chart/kiosk/values.yaml
+++ b/chart/kiosk/values.yaml
@@ -9,23 +9,34 @@ X11:
     tag: latest
   keyboardModMap: null
 
-
 pulseaudio:
   image:
     repository: registry.opensuse.org/home/atgracey/wallboardos/15.6/pa
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: test
+    tag: latest
 
 workload:
+  # Page to load if using firefox as the workload
   url: "https://suse.com"
+  # Additional environment variables to passthrough into the workload
+  env: []
+  # These can be used to provide a custom workload
   image:
     repository: registry.opensuse.org/home/atgracey/wallboardos/15.6/firefox
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
     tag: latest
+    
+  # This is used for side-loading a new trust store for chromium based workloads (including electron.js)
   nssdbSecretName: null
 
+  # These allow for side-loading addtional files into the workload
+  #   Both are a list with each entry having `name` and `mountPath` 
+  #   where `name` is the name of a secret/configmap that exists 
+  #   in the same namespace as this chart
+  #   and mountPath is where the files should be mounted
+  additionalConfigMaps: []
+  additionalSecrets: []
 
 vnc: 
   enabled: false
@@ -42,10 +53,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-
 podLabels: {}
 podAnnotations: {}
 resources: {}
 nodeSelector: {}
 
+# For adding custom hostnames for the workload to use
 hostAliases: []

--- a/chart/kiosk/values.yaml
+++ b/chart/kiosk/values.yaml
@@ -8,6 +8,8 @@ X11:
     # Overrides the image tag whose default is the chart appVersion.
     tag: latest
   keyboardModMap: null
+  # Allows for adding additional commands prior to startx (such as xrandr)
+  xinitrcOverride: null
 
 pulseaudio:
   image:


### PR DESCRIPTION
This includes several changes based on implementation at a customer site.

xinitOverride solves an issue where hypervisor virtual monitors (for dev/test environments) don't allow for the right resolutions to allow for parity with hardware.

The env addition is self-explanatory

additionalSecrets and additionalConfigMaps allow for more operational flexibility with custom workloads