### PR TITLE
drop bash command and arg from pa container

### DIFF
--- a/chart/kiosk/templates/daemonset.yaml
+++ b/chart/kiosk/templates/daemonset.yaml
@@ -57,8 +57,6 @@ spec:
         - name: pulseaudio
           image: {{ .Values.pulseaudio.image.repository }}:{{ .Values.pulseaudio.image.tag }}
           imagePullPolicy: {{ .Values.pulseaudio.image.pullPolicy }}
-          command: ["bash"]
-          args: ["-c", "chmod a+rw /dev/snd/*; pulseaudio"]
           restartPolicy: Always
           securityContext: 
             privileged: true

--- a/containers/pulseaudio/Dockerfile
+++ b/containers/pulseaudio/Dockerfile
@@ -8,4 +8,7 @@ COPY daemon.conf /etc/pulse/
 COPY client.conf /etc/pulse/
 COPY system.pa /etc/pulse/
 
-CMD ["pulseaudio"]
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/containers/pulseaudio/entrypoint.sh
+++ b/containers/pulseaudio/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+log() {
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')] $@"
+}
+
+trap 'log "Received SIGTERM, exiting PulseAudio"; kill -TERM $PA_PID; wait $PA_PID; exit 0' SIGTERM
+trap 'log "Received SIGINT, exiting PulseAudio"; kill -TERM $PA_PID; wait $PA_PID; exit 0' SIGINT
+
+chown root:audio /dev/snd/*
+
+# Start pulseaudio in foreground and capture its PID
+/usr/bin/pulseaudio -vvv --log-target=stderr &
+PA_PID=$!
+
+wait $PA_PID
+log "PulseAudio exited"


### PR DESCRIPTION
Change: Removed command and args from the PulseAudio container in daemonset.yaml, to be handled in the container's entrypoint script.