### PR TITLE
Use exec for starting pulseaudio to ensure pid1

### DIFF
--- a/containers/pulseaudio/entrypoint.sh
+++ b/containers/pulseaudio/entrypoint.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-log() {
-    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')] $@"
-}
-
-trap 'log "Received SIGTERM, exiting PulseAudio"; kill -TERM $PA_PID; wait $PA_PID; exit 0' SIGTERM
-trap 'log "Received SIGINT, exiting PulseAudio"; kill -TERM $PA_PID; wait $PA_PID; exit 0' SIGINT
-
 chown root:audio /dev/snd/*
 
-# Start pulseaudio in foreground and capture its PID
-/usr/bin/pulseaudio -vvv --log-target=stderr &
-PA_PID=$!
-
-wait $PA_PID
-log "PulseAudio exited"
+exec /usr/bin/pulseaudio -vvv --log-target=stderr


### PR DESCRIPTION
Use exec to start pulseaudio in the entrypoint script to ensure it is pid1